### PR TITLE
Disable noPropertyAccessFromIndexSignature

### DIFF
--- a/@ember/app-tsconfig/tsconfig.json
+++ b/@ember/app-tsconfig/tsconfig.json
@@ -47,14 +47,6 @@
     // provides as the default for the currently-specified `module` mode.
     "allowSyntheticDefaultImports": true,
 
-    // --- Lint-style rules
-
-    // https://www.typescriptlang.org/tsconfig/#noPropertyAccessFromIndexSignature
-    //
-    // This setting was historically turned on (true) in @tsconfig/ember, 
-    // But it's mostly been unhelpful, and makes type-ergonomics worse.
-    "noPropertyAccessFromIndexSignature": false,
-
     // --- Compilation/integration settings
     // Setting `noEmitOnError` here allows tools trying to respect the tsconfig
     // to still emit code without breaking on errors.

--- a/@ember/app-tsconfig/tsconfig.json
+++ b/@ember/app-tsconfig/tsconfig.json
@@ -49,10 +49,11 @@
 
     // --- Lint-style rules
 
-    // TypeScript also supplies some lint-style checks; nearly all of them are
-    // better handled by ESLint with the `@typescript-eslint`. This one is more
-    // like a safety check, though, so we leave it on.
-    "noPropertyAccessFromIndexSignature": true,
+    // https://www.typescriptlang.org/tsconfig/#noPropertyAccessFromIndexSignature
+    //
+    // This setting was historically turned on (true) in @tsconfig/ember, 
+    // But it's mostly been unhelpful, and makes type-ergonomics worse.
+    "noPropertyAccessFromIndexSignature": false,
 
     // --- Compilation/integration settings
     // Setting `noEmitOnError` here allows tools trying to respect the tsconfig

--- a/@ember/library-tsconfig/tsconfig.json
+++ b/@ember/library-tsconfig/tsconfig.json
@@ -52,14 +52,6 @@
     // provides as the default for the currently-specified `module` mode.
     "allowSyntheticDefaultImports": true,
 
-    // --- Lint-style rules
-
-    // https://www.typescriptlang.org/tsconfig/#noPropertyAccessFromIndexSignature
-    //
-    // This setting was historically turned on (true) in @tsconfig/ember, 
-    // But it's mostly been unhelpful, and makes type-ergonomics worse.
-    "noPropertyAccessFromIndexSignature": false,
-
     // --- Compilation/integration settings
     // Setting `noEmitOnError` here allows tools trying to respect the tsconfig
     // to still emit code without breaking on errors.

--- a/@ember/library-tsconfig/tsconfig.json
+++ b/@ember/library-tsconfig/tsconfig.json
@@ -54,10 +54,11 @@
 
     // --- Lint-style rules
 
-    // TypeScript also supplies some lint-style checks; nearly all of them are
-    // better handled by ESLint with the `@typescript-eslint`. This one is more
-    // like a safety check, though, so we leave it on.
-    "noPropertyAccessFromIndexSignature": true,
+    // https://www.typescriptlang.org/tsconfig/#noPropertyAccessFromIndexSignature
+    //
+    // This setting was historically turned on (true) in @tsconfig/ember, 
+    // But it's mostly been unhelpful, and makes type-ergonomics worse.
+    "noPropertyAccessFromIndexSignature": false,
 
     // --- Compilation/integration settings
     // Setting `noEmitOnError` here allows tools trying to respect the tsconfig


### PR DESCRIPTION
This makes tsc/glint "looser", so it is non-beraking.

Before: https://www.typescriptlang.org/play/?noPropertyAccessFromIndexSignature=true#code/JYOwLgpgTgZghgYwgAgOJwLYQMoTGUAcwGdkBvAKGWQHobkBpEAewHcRkBXABwFoYozcMm6Du0AhGJVkxcRAAmALmQAieMTCrkAHzVYFwThm17VxADZtVAbhkBHTnAvAwATxWqAFsEJfTalastlQydMgAgsTExihwIG5gPiCEXCAA1izsyGDMOV4ooJCwiBBh9MCkcLJgUEQAdDIA2ukQHjV1KQC6KpqdhHYAvqEIQpqyeAQppAC8yAAMyHCknBlZHMtomDiTRMR2xLvT9XIQinbUl1fIFIf4e-WOzq5uF9fXoeEAqmtsHK1uJYIJDRZhQKpQOIWIKKZBCCjhJKVOEAIwAVhAEGAADRLEAKJaQ5AAAz6RGJtyOJHqnEOUBA2xsQA

After: https://www.typescriptlang.org/play/?#code/JYOwLgpgTgZghgYwgAgOJwLYQMoTGUAcwGdkBvAKGWQHobkBpEAewHcRkBXABwFoYozcMm6Du0AhGJVkxcRAAmALmQAieMTCrkAHzVYFwThm17VxADZtVAbhkBHTnAvAwATxWqAFsEJfTalastlQydMgAgsTExihwIG5gPiCEXCAA1izsyGDMOV4ooJCwiBBh9MCkcLJgUEQAdDIA2ukQHjV1KQC6KpqdhHYAvqEIQpqyeAQppAC8yAAMyHCknBlZHMtomDiTRMR2xLvT9XIQinbUl1fIFIf4e-WOzq5uF9fXoeEAqmtsHK1uJYIJDRZhQKpQOIWIKKZBCCjhJKVOEAIwAVhAEGAADRLEAKJaQ5AAAz6RGJtyOJHqnEOUBA2xsQA