### PR TITLE
Add TypeScript configuration options for declarations

### DIFF
--- a/@ember/library-tsconfig/tsconfig.json
+++ b/@ember/library-tsconfig/tsconfig.json
@@ -16,6 +16,22 @@
     // to enforce using `import type` instead of `import` for Types.
     "verbatimModuleSyntax": true,
 
+    // Require sufficient annotation on exports so other tools can trivially generate declaration files.
+    // (also boosts type-checking performance)
+    "isolatedDeclarations": true,
+
+    // only TypeScript-specific syntax that does not have runtime semantics are supported under this mode. 
+    // In other words, it must be possible to easily erase any TypeScript-specific syntax from a file, 
+    // leaving behind a valid JavaScript file.
+    //
+    // That means the following constructs are not supported:
+    // - enum declarations
+    // - namespaces and modules with runtime code
+    // - parameter properties in classes
+    // - Non-ECMAScript import = and export = assignments
+    // - <prefix>-style type assertions
+    "erasableSyntaxOnly": true,
+
     // v2 addons build using `rollup` and `@babel/plugin-transform-typescript`,
     // which requires file extensions on relative path imports, so we need to
     // support importing `.ts` files.


### PR DESCRIPTION


## Why `isolatedDeclarations: true`

Require sufficient annotation on exports so other tools can trivially generate declaration files (also boosts type-checking performance)

## Why `erasableSyntaxOnly: true`

Allows enforcement non-tsc-powered compilation to be used (required for rolldown, and other non-tsc tools)